### PR TITLE
Issue 527: Duo MFA: pass new SID to subsequent API call to DuoSecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The process goes something like this:
 
 * One of the supported Identity Providers
   * ADFS (2.x or 3.x)
+  * [AzureAD](doc/provider/aad/README.md)
   * PingFederate + PingId
   * [Okta](pkg/provider/okta/README.md)
   * KeyCloak + (TOTP)

--- a/pkg/provider/adfs/adfs.go
+++ b/pkg/provider/adfs/adfs.go
@@ -201,7 +201,7 @@ func checkResponse(doc *goquery.Document) (AuthResponseType, string, error) {
 		if name == "AuthMethod" {
 			val, _ := s.Attr("value")
 			switch val {
-			case "VIPAuthenticationProviderWindowsAccountName":
+			case "VIPAuthenticationProviderWindowsAccountName", "VIPAuthenticationProviderUPN":
 				responseType = MFA_PROMPT
 			case "AzureMfaAuthentication":
 				responseType = AZURE_MFA_WAIT

--- a/pkg/provider/adfs2/rsa.go
+++ b/pkg/provider/adfs2/rsa.go
@@ -115,14 +115,16 @@ func (ac *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Va
 
 	logger.WithField("status", res.StatusCode).WithField("url", loginDetails.URL).WithField("res", dump.ResponseString(res)).Debug("GET")
 
-	// REALLY need to extract the form and actionURL from the previous response
+	// Extract the form and actionURL from the previous response
 
-	authForm := url.Values{}
-	authForm.Add("AuthMethod", "FormsAuthentication")
+	doc, err := goquery.NewDocumentFromResponse(res)
+	authForm, authSubmitURL, err := extractFormData(doc)
 	authForm.Set("UserName", loginDetails.Username)
 	authForm.Set("Password", loginDetails.Password)
 
-	authSubmitURL := fmt.Sprintf("%s/adfs/ls/idpinitiatedsignon", loginDetails.URL)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "error extracting login data")
+	}
 
 	return authSubmitURL, authForm, nil
 }
@@ -200,10 +202,10 @@ func extractFormData(doc *goquery.Document) (url.Values, string, error) {
 			return
 		}
 		val, ok := s.Attr("value")
-		if !ok {
+		if !ok || len(val) == 0 {
 			return
 		}
-		formData.Add(name, val)
+		formData.Set(name, val)
 	})
 
 	return formData, actionURL, nil

--- a/pkg/provider/adfs2/rsa_test.go
+++ b/pkg/provider/adfs2/rsa_test.go
@@ -38,6 +38,7 @@ func TestClient_getLoginForm(t *testing.T) {
 		"UserName":   []string{"test"},
 		"Password":   []string{"test123"},
 		"AuthMethod": []string{"FormsAuthentication"},
+		"Kmsi":       []string{"true"},
 	}, authForm)
 }
 

--- a/pkg/provider/keycloak/example/redirect.html
+++ b/pkg/provider/keycloak/example/redirect.html
@@ -1,0 +1,16 @@
+<HTML>
+
+<HEAD>
+	<TITLE>Kerberos Unsupported</TITLE>
+</HEAD>
+
+<BODY Onload="document.forms[0].submit()">
+	<FORM METHOD="POST" ACTION="https://id.example.com/auth/realms/master/login-actions/authenticate?code=G5PSj-AJ7mC2wRS5yOA5NEGZ7BO97Y0_qUkS5zInmhQ&execution=e0c4f6fe-6f9a-435e-a7ff-d61eb2456d58&client_id=urn%3Aamazon%3Awebservices">
+		<NOSCRIPT>
+			<P>JavaScript is disabled. We strongly recommend to enable it. You were unable to login via Kerberos.  Click the button below to login via an alternative method .</P>
+			<INPUT name="continue" TYPE="SUBMIT" VALUE="CONTINUE" />
+		</NOSCRIPT>
+	</FORM>
+</BODY>
+
+</HTML>

--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -101,6 +101,15 @@ func (kc *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Va
 		return "", nil, errors.Wrap(err, "failed to build document from response")
 	}
 
+	if res.StatusCode == http.StatusUnauthorized {
+		authSubmitURL, err := extractSubmitURL(doc)
+		if err != nil {
+			return "", nil, errors.Wrap(err, "unable to locate IDP authentication form submit URL")
+		}
+		loginDetails.URL = authSubmitURL
+		return kc.getLoginForm(loginDetails)
+	}
+
 	authForm := url.Values{}
 
 	doc.Find("input").Each(func(i int, s *goquery.Selection) {

--- a/pkg/provider/keycloak/keycloak_test.go
+++ b/pkg/provider/keycloak/keycloak_test.go
@@ -59,7 +59,7 @@ func TestClient_getLoginFormRedirect(t *testing.T) {
 			w.Write(data)
 		} else {
 			w.WriteHeader(http.StatusUnauthorized)
-			w.Write(bytes.Replace(redirectData, []byte(exampleLoginURL), []byte("http://" + r.Host), 1))
+			w.Write(bytes.Replace(redirectData, []byte(exampleLoginURL), []byte("http://"+r.Host), 1))
 		}
 		count += 1
 	}))

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -582,6 +582,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 		duoTxResult := gjson.Get(resp, "response.result").String()
 		duoResultURL := gjson.Get(resp, "response.result_url").String()
+		duoSID = gjson.Get(resp, "response.sid").String()
 
 		log.Println(gjson.Get(resp, "response.status").String())
 
@@ -611,6 +612,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 				duoTxResult = gjson.Get(resp, "response.result").String()
 				duoResultURL = gjson.Get(resp, "response.result_url").String()
+				duoSID = gjson.Get(resp, "response.sid").String()
 
 				log.Println(gjson.Get(resp, "response.status").String())
 
@@ -625,6 +627,10 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		}
 
 		duoRequestURL := fmt.Sprintf("https://%s%s", duoHost, duoResultURL)
+
+		duoForm = url.Values{}
+		duoForm.Add("sid", duoSID)
+
 		req, err = http.NewRequest("POST", duoRequestURL, strings.NewReader(duoForm.Encode()))
 		if err != nil {
 			return "", errors.Wrap(err, "error constructing request object to result url")

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -551,7 +551,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		duoTxStat := gjson.Get(resp, "stat").String()
 		duoTxID := gjson.Get(resp, "response.txid").String()
 		if duoTxStat != "OK" {
-			return "", errors.Wrap(err, "error authenticating mfa device")
+			return "", errors.New("error authenticating mfa device")
 		}
 
 		// get duo cookie
@@ -649,9 +649,16 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		}
 
 		resp := string(body)
+
+		duoTxStat = gjson.Get(resp, "stat").String()
+		if duoTxStat != "OK" {
+			message := gjson.Get(resp, "message").String()
+			return "", errors.New(fmt.Sprintf("duoResultSubmit: %s %s", duoTxStat, message))
+		}
+
 		duoTxCookie := gjson.Get(resp, "response.cookie").String()
 		if duoTxCookie == "" {
-			return "", errors.Wrap(err, "duoResultSubmit: Unable to get response.cookie")
+			return "", errors.New("duoResultSubmit: Unable to get response.cookie")
 		}
 
 		// callback to okta with cookie

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -653,7 +653,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		duoTxStat = gjson.Get(resp, "stat").String()
 		if duoTxStat != "OK" {
 			message := gjson.Get(resp, "message").String()
-			return "", errors.New(fmt.Sprintf("duoResultSubmit: %s %s", duoTxStat, message))
+			return "", fmt.Errorf("duoResultSubmit: %s %s", duoTxStat, message)
 		}
 
 		duoTxCookie := gjson.Get(resp, "response.cookie").String()

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -582,7 +582,10 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 		duoTxResult := gjson.Get(resp, "response.result").String()
 		duoResultURL := gjson.Get(resp, "response.result_url").String()
-		duoSID = gjson.Get(resp, "response.sid").String()
+		newSID := gjson.Get(resp, "response.sid").String()
+		if newSID != "" {
+			duoSID = newSID
+		}
 
 		log.Println(gjson.Get(resp, "response.status").String())
 
@@ -612,7 +615,10 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 				duoTxResult = gjson.Get(resp, "response.result").String()
 				duoResultURL = gjson.Get(resp, "response.result_url").String()
-				duoSID = gjson.Get(resp, "response.sid").String()
+				newSID = gjson.Get(resp, "response.sid").String()
+				if newSID != "" {
+					duoSID = newSID
+				}
 
 				log.Println(gjson.Get(resp, "response.status").String())
 


### PR DESCRIPTION
Fixes issue: https://github.com/Versent/saml2aws/issues/527

#### Fix for Duo Security API change: 
- Store the new SID obtained in response from  `POST /frame/status` ( `duoSubmitURL` in code )
- Pass new SID in subsequent API call to `POST /frame/status/<TxID>`  ( `duoResultURL` in code )

#### Bug fixes (this was causing infinite loop for Duo Push MFA failures) :
-  Certain code paths in `verifyMfa` returns `nil` error when in fact it should return an error: `error.Wrap( )` replaced with `error.New( )` : because [wrapping `nil` `err` returns `nil`](https://godoc.org/github.com/pkg/errors#Wrap)